### PR TITLE
hack: fix double overflow for code-blocks

### DIFF
--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -1,5 +1,5 @@
 
-.highlight {
+pre.highlight {
   background-color: #efefef;
   padding: 7px 7px 7px 10px;
   border: 1px solid #ddd;


### PR DESCRIPTION
set .highlight to only apply to pre.hightlight to avoid showing two overflow
containers with scrollbars for <code> snips

(and add a trailing newline :)