### PR TITLE
ripasso-release: NixOS->Nix due to the nixpkgs prefix

### DIFF
--- a/_posts/2019-10-03-Ripasso-release.md
+++ b/_posts/2019-10-03-Ripasso-release.md
@@ -33,7 +33,7 @@ Ripasso is written in rust and so far packaged in nix and arch.
 
 `yay install ripasso-git`
 
-#### NixOS
+#### Nix
 
 `nix-env -iA nixpkgs.ripasso-cursive`
 


### PR DESCRIPTION
To clarify that the installation example applies to the Nix package manager in
general, In NixOS the default channel is `nixos`, and in Nix `nixpkgs`.