### PR TITLE
Update front page: List layout, relative time, remove categories panel globally

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ google_analytics:
 
 # Your website URL (e.g. http://barryclark.github.io or http://www.barryclark.co)
 # Used for Sitemap.xml and your RSS feed
-url: http://blog.hackeriet.no
+url: https://blog.hackeriet.no
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 #
 
 # Name of your site (displayed in the header)
-name: Hackeriet # β
+name: Hackeriet Blog
 
 # Short bio or description (displayed in the header)
 description: Ikke akkurat NRK Beta

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,31 @@
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 
+
+
+    <script type="text/javascript">
+     // From https://github.com/odyniec/tinyAgo-js
+     function ago(val) {
+       val = 0 | (Date.now() - val) / 1000;
+       var unit, length = { second: 60, minute: 60, hour: 24, day: 7, week: 4.35,
+                            month: 12, year: 10000 }, result;
+       for (unit in length) {
+         result = val % length[unit];
+         if (!(val = 0 | val / length[unit]))
+           return result + ' ' + (result-1 ? unit + 's' : unit);
+       }
+     }
+     document.addEventListener("DOMContentLoaded", function(event) {
+       let times = document.getElementsByClassName('ago')
+       for (let t of times) {
+         let datetime = t.getAttribute('datetime')
+         if (!datetime) continue;
+         let date = new Date(datetime);
+         t.innerHTML = "&middot; " + ago(date) + " ago"
+       }
+     });
+
+
       </script>
     <!-- Created with Jekyll Now - http://github.com/barryclark/jekyll-now -->
   </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,14 +13,6 @@
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 
-      <script type="text/javascript">
-          function showStuff(id) {
-              if(document.getElementById(id).style.display == 'block') {
-                  document.getElementById(id).style.display = 'none';
-              } else {
-                  document.getElementById(id).style.display = 'block';
-              }
-          }
       </script>
     <!-- Created with Jekyll Now - http://github.com/barryclark/jekyll-now -->
   </head>
@@ -70,23 +62,6 @@
     {% endunless %}
     {% endif %}
     {% endfor %}
-
-    <div class="categories">
-        <p>Categories</p>
-
-        {% for ct in cats %}
-        <a onClick="showStuff('cat-#{{ ct | slugify }}')" class="codinfox-category-mark" style="color:#999;text-decoration: none;"> {{ ct }} </a> &nbsp;&nbsp;
-        <div id="cat-#{{ ct | slugify }}">
-        {% for post in site.posts %}
-        {% if post.category contains ct %}
-        <p>
-            <a href="{{ post.url }}">{{ post.title }}</a> <small>{{ post.date | date_to_string }}</small>
-        </p>
-        {% endif %}
-        {% endfor %}
-        </div>
-        {% endfor %}
-    </div>
 
     <div class="wrapper-footer">
       <div class="container">

--- a/index.html
+++ b/index.html
@@ -3,48 +3,21 @@ layout: default
 ---
 
 <div class="posts">
-    {% for post in paginator.posts %}
-    <article class="post">
+    {% assign posts_by_month = site.posts | group_by_exp: "item", "item.date | date: '%Y'" %}
 
-        <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
+    <div class="container-fluid">
+        {% for month in posts_by_month %}
+        <b>{{ month.name }}</b>
+        <ul id="posts" style="list-style-type:none;">
+            {% for post in month.items %}
+            <li>
+                <span>{{ post.date | date: "%d %b" }}</span> <a href="{{ post.url }}">{{ post.title }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+        {% endfor %}
+    </div>
 
-        <div class="author">
-            {{ post.date | date: "%d/%m/%y" }} — {{ post.author }}
-        </div>
 
-        <div class="entry">
-            {{ post.excerpt }}
-        </div>
-	{% if post.excerpt != post.content %}
-        	<a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
-	{% endif %}
-    </article>
-    {% endfor %}
 </div>
 
-{% if paginator.total_pages > 1 %}
-<div class="pagination">
-    {% if paginator.previous_page %}
-    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&laquo; Prev</a>
-    {% else %}
-    <span>&laquo; Prev</span>
-    {% endif %}
-
-    {% for page in (1..paginator.total_pages) %}
-    {% if page == paginator.page %}
-    <em>{{ page }}</em>
-    {% elsif page == 1 %}
-    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
-    {% else %}
-    <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
-    {% endif %}
-    {% endfor %}
-
-    {% if paginator.next_page %}
-    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Next &raquo;</a>
-    {% else %}
-    <span>Next &raquo;</span>
-    {% endif %}
-</div>
-{% endif %}
-  

--- a/index.html
+++ b/index.html
@@ -3,21 +3,25 @@ layout: default
 ---
 
 <div class="posts">
-    {% assign posts_by_month = site.posts | group_by_exp: "item", "item.date | date: '%Y'" %}
-
     <div class="container-fluid">
-        {% for month in posts_by_month %}
-        <b>{{ month.name }}</b>
-        <ul id="posts" style="list-style-type:none;">
-            {% for post in month.items %}
-            <li>
-                <span>{{ post.date | date: "%d %b" }}</span> <a href="{{ post.url }}">{{ post.title }}</a>
-            </li>
+        <div class="post-list">
+            {% for post in site.posts %}
+                <div class="post">
+                    <div>
+                        <a href="{{ post.url }}">{{ post.title }}</a>
+                    </div>
+                    <div class="byline">
+                        <time datetime={{ post.date | date: "%Y-%m-%d" }}>{{ post.date | date_to_string }}
+                            <time class="ago" datetime={{ post.date }}></time>
+                        </time>
+                        &middot;
+                        {% for category in post.category %}
+                            <span class="category">{{ category }}</span>
+                            {% endfor %}
+                    </div>
+            </div>
             {% endfor %}
-        </ul>
-        {% endfor %}
+        </div>
     </div>
-
-
 </div>
 

--- a/style.scss
+++ b/style.scss
@@ -166,7 +166,7 @@ th {
 //
 
 .wrapper-masthead {
-  margin-bottom: 50px;
+  margin-bottom: 20px;
 }
 
 .masthead {
@@ -255,6 +255,21 @@ nav {
 //
 // .main
 //
+
+.post-list {
+  .post {
+    padding-bottom:0.5em;
+
+  }
+  .byline {
+    font-size:0.8em;
+    color:#666;
+  }
+  .category {
+    padding-left:0.2em;
+    padding-right:0.2em;
+  }
+}
 
 .posts > .post {
   padding-bottom: 2em;


### PR DESCRIPTION
Update the front page a bit:
- List view, easier to see what's new, and find older stuff
- Shows the relative time for posts in the list
- Removes the category list on the right hand side for all pages (as it doesn't work well on mobile etc.)

![Screen Shot 2022-04-26 at 01 35 29](https://user-images.githubusercontent.com/75371/165191508-86309638-8d01-4eed-8d9d-e074a4af42a8.png)
